### PR TITLE
[Feat] Payment 도메인 특정 카테고리 결제 내역 반환 기능 추가

### DIFF
--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/category/repository/CategoryRepository.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/category/repository/CategoryRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
+    boolean existsByNameIgnoreCase(String name);
     Optional<Category> findByNameIgnoreCase(String name);
 
 }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/payment/controller/PaymentController.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/payment/controller/PaymentController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.time.LocalDate;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/payments")
@@ -25,10 +26,11 @@ public class PaymentController {
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
             @RequestParam(required = false, defaultValue = "0") int page,
-            @RequestParam(required = false, defaultValue = "15") int size
+            @RequestParam(required = false, defaultValue = "15") int size,
+            @RequestParam(required = false) String category
             ) {
 
-        PaymentResponseDto.Payments dto = paymentService.getMonthly(from, to, page, size);
+        PaymentResponseDto.Payments dto = paymentService.getMonthly(from, to, page, size, Optional.ofNullable(category));
 
         return ResponseEntity.ok(dto);
     }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/payment/repository/PaymentRepository.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/payment/repository/PaymentRepository.java
@@ -5,9 +5,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
@@ -19,10 +21,15 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
      * @param pageable 페이징 정보
      * @return
      */
-    @Query("SELECT p FROM Payment p " +
-            "WHERE function('date', p.transactionAt) BETWEEN :from AND :to")
     Page<Payment> findByTransactionAtBetween(
-            LocalDate from,
-            LocalDate to,
+            LocalDateTime from,
+            LocalDateTime to,
             Pageable pageable);
+
+    Page<Payment> findByCategory_NameIgnoreCaseAndTransactionAtBetween(
+            String category,             // 카테고리 이름
+            LocalDateTime from,
+            LocalDateTime to,
+            Pageable pageable);
+
 }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/payment/service/PaymentService.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/payment/service/PaymentService.java
@@ -4,13 +4,18 @@ import com.wisespendinglife.wise_spending_life.domain.payment.dto.PaymentRequest
 import com.wisespendinglife.wise_spending_life.domain.payment.dto.PaymentResponseDto;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 /*
  * Payment Service Interface
  */
 public interface PaymentService {
 
-    PaymentResponseDto.Payments getMonthly(LocalDate from, LocalDate to, int currentPage, int size);
+    PaymentResponseDto.Payments getMonthly(LocalDate from,
+                                           LocalDate to,
+                                           int currentPage,
+                                           int size,
+                                           Optional<String> categoryOpt);
 
     public PaymentResponseDto.PaymentCreateResponseDto create(PaymentRequestDto.CreateDto dto);
 

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/payment/service/PaymentServiceImpl.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/payment/service/PaymentServiceImpl.java
@@ -20,6 +20,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 @AllArgsConstructor
@@ -32,16 +34,35 @@ public class PaymentServiceImpl implements PaymentService {
     private final PaymentConverter converter;
     private final PaymentResponseAssembler responseAssembler;
 
-    public PaymentResponseDto.Payments getMonthly(LocalDate from, LocalDate to, int currentPage, int size) {
+    public PaymentResponseDto.Payments getMonthly(LocalDate from,
+                                                  LocalDate to,
+                                                  int currentPage,
+                                                  int size,
+                                                  Optional<String> categoryOpt) {
 
         if(from.isAfter(to)) throw new BusinessException(ErrorCode.INVALID_DATE_REQUEST);
+
+        LocalDateTime start = from.atStartOfDay();          // 2025-07-01 00:00
+        LocalDateTime end   = to.plusDays(1).atStartOfDay();
 
         // Pageable 설정
         Pageable pageable = PageRequest.of(currentPage, size, Sort.by(Sort.Order.desc("transactionAt"),
                 Sort.Order.desc("id")).descending());
 
         // Page 조회
-        Page<Payment> page = paymentRepository.findByTransactionAtBetween(from, to, pageable);
+        Page<Payment> page = categoryOpt
+                .map(cat -> {
+                    // ❶ 존재 여부 검증
+                    if (!categoryRepository.existsByNameIgnoreCase(cat))
+                        throw new BusinessException(ErrorCode.CATEGORY_NOT_FOUND);
+
+                    // ❷ 정상이라면 조회
+                    return paymentRepository
+                            .findByCategory_NameIgnoreCaseAndTransactionAtBetween(
+                                    cat, start, end, pageable);
+                })
+                .orElseGet(() -> paymentRepository
+                        .findByTransactionAtBetween(start, end, pageable));
 
         // Response 생성
         return responseAssembler.assemble(from, to, page);


### PR DESCRIPTION
## ✨ 새로운 기능
결제내역 API 를 호출 할 때 쿼리파라미터로 category 를 추가하고 카테고리 이름을 값으로 넣으면 해당 카테고리의 결제 내역이 반환됩니다.

예시:
/api/payments?from=2025-07-01&to=2025-07-31&page=0&category=교육

## 🔧 주요 변경 사항
- [x] Controller 와 Service 에 category 처리 로직 추가
- [x] LocalDateTime -> LocalDate 변환 로직 추가_(레포지토리 파일에 Query 를 제거할 수 있게 되었음)_

## ✅ 테스트 계획
- [x] 잘못된 카테고리 값 넣고 요청. category=아무개
- [x] 카테고리 키/값 넣지 않고 요청
- [x] 정상적인 카테고리 값 넣고 요청

## 📝 기타 사항

Close #11 