### PR TITLE
Feature/21

### DIFF
--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/category/repository/CategoryRepository.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/category/repository/CategoryRepository.java
@@ -11,5 +11,5 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     boolean existsByNameIgnoreCase(String name);
     Optional<Category> findByNameIgnoreCase(String name);
-
+    Optional<Category> findByName(String name);
 }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/controller/ChallengeController.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/controller/ChallengeController.java
@@ -37,19 +37,19 @@ public class ChallengeController {
         return ResponseEntity.ok(validChallenge);
     }
 
-    @GetMapping("/{challengeId}")
+    @GetMapping("/{challenge_id}")
     public ResponseEntity<ChallengeDetailResponseDto> getChallengeById(
-            @PathVariable("challengeId") Long challengeId
+            @PathVariable("challenge_id") Long challenge_id
     ){
-        ChallengeDetailResponseDto challengeDetailResponseDto = challengeService.findChallengeById(challengeId);
+        ChallengeDetailResponseDto challengeDetailResponseDto = challengeService.findChallengeById(challenge_id);
         return ResponseEntity.ok(challengeDetailResponseDto);
     }
 
-    @DeleteMapping("/{challengeId}")
+    @DeleteMapping("/{challenge_id}")
     public ResponseEntity<?> deleteChallenge(
-            @PathVariable("challengeId") Long challengeId
+            @PathVariable("challenge_id") Long challenge_id
     ){
-        challengeService.deleteChallenge(challengeId);
+        challengeService.deleteChallenge(challenge_id);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(Map.of("msg", "챌린지를 성공적으로 삭제했습니다."));
     }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/controller/ChallengeController.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/controller/ChallengeController.java
@@ -1,6 +1,7 @@
 package com.wisespendinglife.wise_spending_life.domain.challenge.controller;
 
 import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ChallengeCreateRequestDto;
+import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ChallengeDetailResponseDto;
 import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ValidChallengeResponseDto;
 import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge;
 import com.wisespendinglife.wise_spending_life.domain.challenge.service.ChallengeService;
@@ -34,5 +35,13 @@ public class ChallengeController {
     ){
         ValidChallengeResponseDto validChallenge = challengeService.findValidChallenge(isCompleted, isDeleted);
         return ResponseEntity.ok(validChallenge);
+    }
+
+    @GetMapping("/{challengeId}")
+    public ResponseEntity<ChallengeDetailResponseDto> getChallengeById(
+            @PathVariable("challengeId") Long challengeId
+    ){
+        ChallengeDetailResponseDto challengeDetailResponseDto = challengeService.findChallengeById(challengeId);
+        return ResponseEntity.ok(challengeDetailResponseDto);
     }
 }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/controller/ChallengeController.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/controller/ChallengeController.java
@@ -1,0 +1,32 @@
+package com.wisespendinglife.wise_spending_life.domain.challenge.controller;
+
+import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ChallengeCreateRequestDto;
+import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge;
+import com.wisespendinglife.wise_spending_life.domain.challenge.service.ChallengeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/challenges")
+public class ChallengeController {
+    private final ChallengeService challengeService;
+
+    @PostMapping
+    public ResponseEntity<?> createChallenge(
+            @Validated @RequestBody ChallengeCreateRequestDto challengeCreateRequestDto
+            )
+    {
+        Challenge createdChallenge = challengeService.createChallenge(challengeCreateRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(Map.of("msg", "챌린지가 성공적으로 생성되었습니다."));
+    }
+}

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/controller/ChallengeController.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/controller/ChallengeController.java
@@ -1,6 +1,7 @@
 package com.wisespendinglife.wise_spending_life.domain.challenge.controller;
 
 import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ChallengeCreateRequestDto;
+import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ChallengeCreateResponseDto;
 import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ChallengeDetailResponseDto;
 import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ValidChallengeResponseDto;
 import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge;
@@ -24,8 +25,24 @@ public class ChallengeController {
             @Validated @RequestBody ChallengeCreateRequestDto challengeCreateRequestDto
     ){
         Challenge createdChallenge = challengeService.createChallenge(challengeCreateRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(Map.of("msg", "챌린지가 성공적으로 생성되었습니다."));
+        ChallengeCreateResponseDto responseDto = ChallengeCreateResponseDto.builder()
+                .id(createdChallenge.getId())
+                .user_id(createdChallenge.getUser().getId())
+                .challengeName(createdChallenge.getChallengeName())
+                .challengeType(createdChallenge.getChallengeType())
+                .challengeDays(createdChallenge.getChallengeDays())
+                .startAt(createdChallenge.getStartAt())
+                .endAt(createdChallenge.getEndAt())
+                .createdAt(createdChallenge.getCreatedAt())
+                .categories(createdChallenge.getChallengeCategories()
+                        .stream()
+                        .map(v -> v.getCategory().getName())
+                        .toList())
+                .characterImageUrl(createdChallenge.getCharacterImageUrl())
+                .isCompleted(createdChallenge.getIsCompleted())
+                .isDeleted(createdChallenge.getIsDeleted())
+                .build();
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
     @GetMapping

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/controller/ChallengeController.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/controller/ChallengeController.java
@@ -1,16 +1,14 @@
 package com.wisespendinglife.wise_spending_life.domain.challenge.controller;
 
 import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ChallengeCreateRequestDto;
+import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ValidChallengeResponseDto;
 import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge;
 import com.wisespendinglife.wise_spending_life.domain.challenge.service.ChallengeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -23,10 +21,18 @@ public class ChallengeController {
     @PostMapping
     public ResponseEntity<?> createChallenge(
             @Validated @RequestBody ChallengeCreateRequestDto challengeCreateRequestDto
-            )
-    {
+    ){
         Challenge createdChallenge = challengeService.createChallenge(challengeCreateRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(Map.of("msg", "챌린지가 성공적으로 생성되었습니다."));
+    }
+
+    @GetMapping
+    public ResponseEntity<ValidChallengeResponseDto> getValidChallenge(
+            @RequestParam("isCompleted") boolean isCompleted,
+            @RequestParam("isDeleted") boolean isDeleted
+    ){
+        ValidChallengeResponseDto validChallenge = challengeService.findValidChallenge(isCompleted, isDeleted);
+        return ResponseEntity.ok(validChallenge);
     }
 }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/controller/ChallengeController.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/controller/ChallengeController.java
@@ -44,4 +44,13 @@ public class ChallengeController {
         ChallengeDetailResponseDto challengeDetailResponseDto = challengeService.findChallengeById(challengeId);
         return ResponseEntity.ok(challengeDetailResponseDto);
     }
+
+    @DeleteMapping("/{challengeId}")
+    public ResponseEntity<?> deleteChallenge(
+            @PathVariable("challengeId") Long challengeId
+    ){
+        challengeService.deleteChallenge(challengeId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(Map.of("msg", "챌린지를 성공적으로 삭제했습니다."));
+    }
 }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/dto/ChallengeCreateRequestDto.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/dto/ChallengeCreateRequestDto.java
@@ -19,14 +19,14 @@ import java.util.List;
 @Builder
 public class ChallengeCreateRequestDto {
     @NotNull(message = "{INVALID_USER_ID}")
-    @Schema(description = "사용자 ID", example = "15")
+    @Schema(description = "사용자 ID", example = "1")
     private Long user_id;
     @NotBlank(message = "{INVALID_CHALLENGE_NAME}")
     @Size(max = 50, message = "{INVALID_CHALLENGE_NAME}")
     @Schema(description = "챌린지 이름", example = "식비 줄이기 챌린지")
     private String challengeName;
     @NotNull(message = "{INVALID_CHALLENGE_TYPE}")
-    @Schema(description = "챌린지 타입", example = "적게 쓰기")
+    @Schema(description = "챌린지 타입", example = "pay_less")
     private ChallengeType challengeType;
     @NotNull(message = "{INVALID_CHALLENGE_DAYS}")
     @Schema(description = "챌린지 일수", example = "3")

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/dto/ChallengeCreateRequestDto.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/dto/ChallengeCreateRequestDto.java
@@ -1,0 +1,52 @@
+package com.wisespendinglife.wise_spending_life.domain.challenge.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.wisespendinglife.wise_spending_life.domain.challenge.entity.ChallengeType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ChallengeCreateRequestDto {
+    @NotNull(message = "{INVALID_USER_ID}")
+    @Schema(description = "사용자 ID", example = "15")
+    private Long userId;
+    @NotBlank(message = "{INVALID_CHALLENGE_NAME}")
+    @Size(max = 50, message = "{INVALID_CHALLENGE_NAME}")
+    @Schema(description = "챌린지 이름", example = "식비 줄이기 챌린지")
+    private String challengeName;
+    @NotNull(message = "{INVALID_CHALLENGE_TYPE}")
+    @Schema(description = "챌린지 타입", example = "적게 쓰기")
+    private ChallengeType challengeType;
+    @NotNull(message = "{INVALID_CHALLENGE_DAYS}")
+    @Schema(description = "챌린지 일수", example = "3")
+    private Long challengeDays;
+
+    @NotNull(message = "{INVALID_START_AT}")
+    @Schema(description = "시작일", example = "2025-08-04")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startAt;
+    @NotNull(message = "{INVALID_END_AT}")
+    @Schema(description = "종료일", example = "2025-08-07")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endAt;
+    @NotNull(message = "{INVALID_CREATED_AT}")
+    @Schema(description = "생성일", example = "2025-08-04")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate createdAt;
+
+    @NotEmpty(message = "{INVALID_CATEGORIES}")
+    @Schema(description = "카테고리 선택", example = "식비")
+    private List<String> categories;
+
+}

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/dto/ChallengeCreateRequestDto.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/dto/ChallengeCreateRequestDto.java
@@ -20,7 +20,7 @@ import java.util.List;
 public class ChallengeCreateRequestDto {
     @NotNull(message = "{INVALID_USER_ID}")
     @Schema(description = "사용자 ID", example = "15")
-    private Long userId;
+    private Long user_id;
     @NotBlank(message = "{INVALID_CHALLENGE_NAME}")
     @Size(max = 50, message = "{INVALID_CHALLENGE_NAME}")
     @Schema(description = "챌린지 이름", example = "식비 줄이기 챌린지")

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/dto/ChallengeCreateResponseDto.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/dto/ChallengeCreateResponseDto.java
@@ -1,0 +1,43 @@
+package com.wisespendinglife.wise_spending_life.domain.challenge.dto;
+
+import com.wisespendinglife.wise_spending_life.domain.challenge.entity.ChallengeType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+public class ChallengeCreateResponseDto {
+    private final Long id;
+    private final Long userId;
+    private final String challengeName;
+    private final ChallengeType challengeType;
+    private final Long challengeDays;
+    private final LocalDate startAt;
+    private final LocalDate endAt;
+    private final LocalDate createdAt;
+    private final List<String> categories;
+    private final String characterImageUrl;
+    private final Boolean isCompleted;
+    private final Boolean isDeleted;
+
+    @Builder
+    public ChallengeCreateResponseDto(Long id, Long userId, String challengeName,
+                                      ChallengeType challengeType, Long challengeDays, LocalDate startAt,
+                                      LocalDate endAt, LocalDate createdAt, List<String> categories,
+                                      String characterImageUrl, Boolean isCompleted, Boolean isDeleted) {
+        this.id = id;
+        this.userId = userId;
+        this.challengeName = challengeName;
+        this.challengeType = challengeType;
+        this.challengeDays = challengeDays;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.createdAt = createdAt;
+        this.categories = categories;
+        this.characterImageUrl = characterImageUrl;
+        this.isCompleted = isCompleted;
+        this.isDeleted = isDeleted;
+    }
+}

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/dto/ChallengeCreateResponseDto.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/dto/ChallengeCreateResponseDto.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 public class ChallengeCreateResponseDto {
     private final Long id;
-    private final Long userId;
+    private final Long user_id;
     private final String challengeName;
     private final ChallengeType challengeType;
     private final Long challengeDays;
@@ -23,12 +23,12 @@ public class ChallengeCreateResponseDto {
     private final Boolean isDeleted;
 
     @Builder
-    public ChallengeCreateResponseDto(Long id, Long userId, String challengeName,
+    public ChallengeCreateResponseDto(Long id, Long user_id, String challengeName,
                                       ChallengeType challengeType, Long challengeDays, LocalDate startAt,
                                       LocalDate endAt, LocalDate createdAt, List<String> categories,
                                       String characterImageUrl, Boolean isCompleted, Boolean isDeleted) {
         this.id = id;
-        this.userId = userId;
+        this.user_id = user_id;
         this.challengeName = challengeName;
         this.challengeType = challengeType;
         this.challengeDays = challengeDays;

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/dto/ChallengeDetailResponseDto.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/dto/ChallengeDetailResponseDto.java
@@ -1,0 +1,38 @@
+package com.wisespendinglife.wise_spending_life.domain.challenge.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge;
+import com.wisespendinglife.wise_spending_life.domain.challenge.entity.ChallengeType;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class ChallengeDetailResponseDto {
+    private final Long id;
+    private final String challengeName;
+    private final ChallengeType challengeType;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private final LocalDate startAt;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private final LocalDate endAt;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private final LocalDate createdAt;
+
+    private final List<String> categories;
+
+    public ChallengeDetailResponseDto(Challenge challenge) {
+        this.id = challenge.getId();
+        this.challengeName = challenge.getChallengeName();
+        this.challengeType = challenge.getChallengeType();
+        this.startAt = challenge.getStartAt();
+        this.endAt = challenge.getEndAt();
+        this.createdAt = challenge.getCreatedAt();
+        this.categories = challenge.getChallengeCategories().stream()
+                .map(challengeCategory -> challengeCategory.getCategory().getName())
+                .collect(Collectors.toList());
+    }
+}

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/dto/ValidChallengeResponseDto.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/dto/ValidChallengeResponseDto.java
@@ -1,0 +1,42 @@
+package com.wisespendinglife.wise_spending_life.domain.challenge.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge;
+import com.wisespendinglife.wise_spending_life.domain.challenge.entity.ChallengeType;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+@Getter
+public class ValidChallengeResponseDto {
+    private final Long id;
+    private final String challengeName;
+    private final ChallengeType challengeType;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private final LocalDate startAt;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private final LocalDate endAt;
+
+    private final long remainingDays; // DATEDIFF(endAt, CURRENT_DATE)
+
+    public ValidChallengeResponseDto(Long id, String challengeName, ChallengeType challengeType,
+                                     LocalDate startAt, LocalDate endAt, long remainingDays) {
+        this.id = id;
+        this.challengeName = challengeName;
+        this.challengeType = challengeType;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.remainingDays = remainingDays;
+    }
+
+    public ValidChallengeResponseDto(Challenge challenge) {
+        this.id = challenge.getId();
+        this.challengeName = challenge.getChallengeName();
+        this.challengeType = challenge.getChallengeType();
+        this.startAt = challenge.getStartAt();
+        this.endAt = challenge.getEndAt();
+        this.remainingDays = ChronoUnit.DAYS.between(LocalDate.now(), challenge.getEndAt());
+    }
+}

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/entity/Challenge.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/entity/Challenge.java
@@ -57,4 +57,12 @@ public class Challenge {
         this.isCompleted = isCompleted;
         this.isDeleted = isDeleted;
     }
+
+    public void setIsCompleted() {
+        this.isCompleted = true;
+    }
+
+    public void setIsDeleted(){
+        this.isDeleted = true;
+    }
 }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/entity/Challenge.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/entity/Challenge.java
@@ -1,0 +1,60 @@
+package com.wisespendinglife.wise_spending_life.domain.challenge.entity;
+
+import com.wisespendinglife.wise_spending_life.domain.user.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "challenge")
+public class Challenge {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    private String challengeName;
+    @Enumerated(EnumType.STRING)
+    private ChallengeType challengeType;
+    private Long challengeDays;
+    private LocalDate startAt;
+    private LocalDate endAt;
+    private LocalDate createdAt;
+    private String characterImageUrl;
+    private Boolean isCompleted;
+    private Boolean isDeleted;
+
+    @OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChallengeCategory> challengeCategories = new ArrayList<>();
+
+    public void addChallengeCategory(ChallengeCategory challengeCategory) {
+        this.challengeCategories.add(challengeCategory);
+        challengeCategory.setChallengeCategory(this);
+    }
+
+    @Builder
+    public Challenge(UserEntity user, String challengeName, ChallengeType challengeType,
+                     Long challengeDays, LocalDate startAt, LocalDate endAt, LocalDate createdAt,
+                     String characterImageUrl, Boolean isCompleted, Boolean isDeleted) {
+        this.user = user;
+        this.challengeName = challengeName;
+        this.challengeType = challengeType;
+        this.challengeDays = challengeDays;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.createdAt = createdAt;
+        this.characterImageUrl = characterImageUrl;
+        this.isCompleted = isCompleted;
+        this.isDeleted = isDeleted;
+    }
+}

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/entity/ChallengeCategory.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/entity/ChallengeCategory.java
@@ -1,0 +1,32 @@
+package com.wisespendinglife.wise_spending_life.domain.challenge.entity;
+
+import com.wisespendinglife.wise_spending_life.domain.category.entity.Category;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "challenge_category")
+public class ChallengeCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "challenge_id")
+    private Challenge challenge;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    public ChallengeCategory(Category category) {
+        this.category = category;
+    }
+
+    void setChallengeCategory(Challenge challenge) {
+        this.challenge = challenge;
+    }
+}

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/entity/ChallengeType.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/entity/ChallengeType.java
@@ -1,0 +1,29 @@
+package com.wisespendinglife.wise_spending_life.domain.challenge.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.wisespendinglife.wise_spending_life.global.error.BusinessException;
+import com.wisespendinglife.wise_spending_life.global.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.stream.Stream;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChallengeType {
+    PAY_NOT("pay_not"),
+    PAY_LESS("pay_less"),
+    PAY_SAVE("pay_save");
+
+    @JsonValue
+    private final String value;
+
+    @JsonCreator
+    public static ChallengeType fromValue(String value) {
+        return Stream.of(values())
+                .filter(v -> v.getValue().equals(value))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ErrorCode.CHALLENGE_TYPE_NOT_FOUND));
+    }
+}

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/repository/ChallengeRepository.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/repository/ChallengeRepository.java
@@ -1,0 +1,7 @@
+package com.wisespendinglife.wise_spending_life.domain.challenge.repository;
+
+import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+}

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/repository/ChallengeRepository.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/repository/ChallengeRepository.java
@@ -3,5 +3,8 @@ package com.wisespendinglife.wise_spending_life.domain.challenge.repository;
 import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+    Optional<Challenge> findByIsCompletedAndIsDeleted(Boolean isCompleted, Boolean isDeleted);
 }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeService.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeService.java
@@ -1,0 +1,8 @@
+package com.wisespendinglife.wise_spending_life.domain.challenge.service;
+
+import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ChallengeCreateRequestDto;
+import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge;
+
+public interface ChallengeService {
+    public Challenge createChallenge(ChallengeCreateRequestDto dto);
+}

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeService.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeService.java
@@ -10,4 +10,5 @@ public interface ChallengeService {
     public Challenge createChallenge(ChallengeCreateRequestDto dto);
     public ValidChallengeResponseDto findValidChallenge(boolean isCompleted, boolean isDeleted);
     public ChallengeDetailResponseDto findChallengeById(Long challengeId);
+    public void deleteChallenge(Long challengeId);
 }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeService.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeService.java
@@ -9,6 +9,6 @@ import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge
 public interface ChallengeService {
     public Challenge createChallenge(ChallengeCreateRequestDto dto);
     public ValidChallengeResponseDto findValidChallenge(boolean isCompleted, boolean isDeleted);
-    public ChallengeDetailResponseDto findChallengeById(Long challengeId);
-    public void deleteChallenge(Long challengeId);
+    public ChallengeDetailResponseDto findChallengeById(Long challenge_id);
+    public void deleteChallenge(Long challenge_id);
 }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeService.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeService.java
@@ -1,6 +1,7 @@
 package com.wisespendinglife.wise_spending_life.domain.challenge.service;
 
 import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ChallengeCreateRequestDto;
+import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ChallengeDetailResponseDto;
 import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ValidChallengeResponseDto;
 import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge;
 
@@ -8,4 +9,5 @@ import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge
 public interface ChallengeService {
     public Challenge createChallenge(ChallengeCreateRequestDto dto);
     public ValidChallengeResponseDto findValidChallenge(boolean isCompleted, boolean isDeleted);
+    public ChallengeDetailResponseDto findChallengeById(Long challengeId);
 }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeService.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeService.java
@@ -1,8 +1,11 @@
 package com.wisespendinglife.wise_spending_life.domain.challenge.service;
 
 import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ChallengeCreateRequestDto;
+import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ValidChallengeResponseDto;
 import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge;
+
 
 public interface ChallengeService {
     public Challenge createChallenge(ChallengeCreateRequestDto dto);
+    public ValidChallengeResponseDto findValidChallenge(boolean isCompleted, boolean isDeleted);
 }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeServiceImpl.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeServiceImpl.java
@@ -39,7 +39,8 @@ public class ChallengeServiceImpl implements ChallengeService {
                 .startAt(dto.getStartAt())
                 .endAt(dto.getEndAt())
                 .createdAt(dto.getCreatedAt())
-                .characterImageUrl("url") // url 설정하기 (필요함)
+                // <TODO: 사용자가 설정한 캐릭터를 토대로 url을 받아와야 하는데, 상황에 맞는 캐릭터 이미지를 어떻게 받아올 지 설정 필요>
+                .characterImageUrl("url")
                 .isCompleted(false) // 미완료로 자동 세팅
                 .isDeleted(false) // 미삭제로 자동 세팅
                 .build();

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeServiceImpl.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeServiceImpl.java
@@ -28,7 +28,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     @Override
     @Transactional
     public Challenge createChallenge(ChallengeCreateRequestDto dto) {
-        UserEntity user = userRepository.findById(dto.getUserId())
+        UserEntity user = userRepository.findById(dto.getUser_id())
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         Challenge newchallenge = Challenge.builder()
@@ -62,16 +62,16 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     @Override
     @Transactional(readOnly = true)
-    public ChallengeDetailResponseDto findChallengeById(Long challengeId) {
-        Challenge challenge = challengeRepository.findById(challengeId)
+    public ChallengeDetailResponseDto findChallengeById(Long challenge_id) {
+        Challenge challenge = challengeRepository.findById(challenge_id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CERTAIN_CHALLENGE_NOT_FOUND));
         return new ChallengeDetailResponseDto(challenge);
     }
 
     @Override
     @Transactional
-    public void deleteChallenge(Long challengeId) {
-        Challenge challenge = challengeRepository.findById(challengeId)
+    public void deleteChallenge(Long challenge_id) {
+        Challenge challenge = challengeRepository.findById(challenge_id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CERTAIN_CHALLENGE_NOT_FOUND));
         // 삭제된 것으로 처리
         challenge.setIsDeleted();

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeServiceImpl.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeServiceImpl.java
@@ -3,6 +3,7 @@ package com.wisespendinglife.wise_spending_life.domain.challenge.service;
 import com.wisespendinglife.wise_spending_life.domain.category.entity.Category;
 import com.wisespendinglife.wise_spending_life.domain.category.repository.CategoryRepository;
 import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ChallengeCreateRequestDto;
+import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ChallengeDetailResponseDto;
 import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ValidChallengeResponseDto;
 import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge;
 import com.wisespendinglife.wise_spending_life.domain.challenge.entity.ChallengeCategory;
@@ -57,5 +58,13 @@ public class ChallengeServiceImpl implements ChallengeService {
         return challengeRepository.findByIsCompletedAndIsDeleted(isCompleted, isDeleted)
                 .map(ValidChallengeResponseDto::new)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CHALLENGE_NOT_FOUND));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ChallengeDetailResponseDto findChallengeById(Long challengeId) {
+        Challenge challenge = challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CERTAIN_CHALLENGE_NOT_FOUND));
+        return new ChallengeDetailResponseDto(challenge);
     }
 }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeServiceImpl.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeServiceImpl.java
@@ -3,6 +3,7 @@ package com.wisespendinglife.wise_spending_life.domain.challenge.service;
 import com.wisespendinglife.wise_spending_life.domain.category.entity.Category;
 import com.wisespendinglife.wise_spending_life.domain.category.repository.CategoryRepository;
 import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ChallengeCreateRequestDto;
+import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ValidChallengeResponseDto;
 import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge;
 import com.wisespendinglife.wise_spending_life.domain.challenge.entity.ChallengeCategory;
 import com.wisespendinglife.wise_spending_life.domain.challenge.repository.ChallengeRepository;
@@ -12,6 +13,7 @@ import com.wisespendinglife.wise_spending_life.global.error.BusinessException;
 import com.wisespendinglife.wise_spending_life.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -23,6 +25,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     private final CategoryRepository categoryRepository;
 
     @Override
+    @Transactional
     public Challenge createChallenge(ChallengeCreateRequestDto dto) {
         UserEntity user = userRepository.findById(dto.getUserId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
@@ -46,5 +49,13 @@ public class ChallengeServiceImpl implements ChallengeService {
             newchallenge.addChallengeCategory(new ChallengeCategory(category));
         }
         return challengeRepository.save(newchallenge);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ValidChallengeResponseDto findValidChallenge(boolean isCompleted, boolean isDeleted) {
+        return challengeRepository.findByIsCompletedAndIsDeleted(isCompleted, isDeleted)
+                .map(ValidChallengeResponseDto::new)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CHALLENGE_NOT_FOUND));
     }
 }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeServiceImpl.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeServiceImpl.java
@@ -67,4 +67,16 @@ public class ChallengeServiceImpl implements ChallengeService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.CERTAIN_CHALLENGE_NOT_FOUND));
         return new ChallengeDetailResponseDto(challenge);
     }
+
+    @Override
+    @Transactional
+    public void deleteChallenge(Long challengeId) {
+        Challenge challenge = challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CERTAIN_CHALLENGE_NOT_FOUND));
+        // 삭제된 것으로 처리
+        challenge.setIsDeleted();
+        challengeRepository.save(challenge);
+        // 물리 삭제
+//        challengeRepository.delete(challenge);
+    }
 }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeServiceImpl.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/challenge/service/ChallengeServiceImpl.java
@@ -1,0 +1,50 @@
+package com.wisespendinglife.wise_spending_life.domain.challenge.service;
+
+import com.wisespendinglife.wise_spending_life.domain.category.entity.Category;
+import com.wisespendinglife.wise_spending_life.domain.category.repository.CategoryRepository;
+import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ChallengeCreateRequestDto;
+import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge;
+import com.wisespendinglife.wise_spending_life.domain.challenge.entity.ChallengeCategory;
+import com.wisespendinglife.wise_spending_life.domain.challenge.repository.ChallengeRepository;
+import com.wisespendinglife.wise_spending_life.domain.user.entity.UserEntity;
+import com.wisespendinglife.wise_spending_life.domain.user.repository.UserRepository;
+import com.wisespendinglife.wise_spending_life.global.error.BusinessException;
+import com.wisespendinglife.wise_spending_life.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeServiceImpl implements ChallengeService {
+    private final ChallengeRepository challengeRepository;
+    private final UserRepository userRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public Challenge createChallenge(ChallengeCreateRequestDto dto) {
+        UserEntity user = userRepository.findById(dto.getUserId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Challenge newchallenge = Challenge.builder()
+                .user(user)
+                .challengeName(dto.getChallengeName())
+                .challengeType(dto.getChallengeType())
+                .challengeDays(dto.getChallengeDays())
+                .startAt(dto.getStartAt())
+                .endAt(dto.getEndAt())
+                .createdAt(dto.getCreatedAt())
+                .characterImageUrl("url") // url 설정하기 (필요함)
+                .isCompleted(false) // 미완료로 자동 세팅
+                .isDeleted(false) // 미삭제로 자동 세팅
+                .build();
+        List<String> categoryNames = dto.getCategories();
+        for (String categoryName : categoryNames) {
+            Category category = categoryRepository.findByName(categoryName)
+                    .orElseThrow(()-> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+            newchallenge.addChallengeCategory(new ChallengeCategory(category));
+        }
+        return challengeRepository.save(newchallenge);
+    }
+}

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/global/error/ErrorCode.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/global/error/ErrorCode.java
@@ -32,9 +32,14 @@ public enum ErrorCode {
     INVALID_GENDER(HttpStatus.BAD_REQUEST, "4016", "성별은 필수 입력 항목입니다."),
     INVALID_AGE(HttpStatus.BAD_REQUEST, "4017", "나이는 필수 입력 항목입니다."),
     INVALID_BASE_AMOUNT(HttpStatus.BAD_REQUEST, "4018", "기준 금액은 필수 입력 항목입니다."),
-
-
-
+    INVALID_USER_ID(HttpStatus.BAD_REQUEST, "4019", "사용자 ID는 필수 입력 항목입니다."),
+    INVALID_CHALLENGE_NAME(HttpStatus.BAD_REQUEST, "4020", "챌린지 이름은 필수 입력 항목입니다."),
+    INVALID_CHALLENGE_TYPE(HttpStatus.BAD_REQUEST, "4021", "챌린지 타입은 필수 입력 항목입니다."),
+    INVALID_CHALLENGE_DAYS(HttpStatus.BAD_REQUEST, "4022", "챌린지 일수는 필수 입력 항목입니다."),
+    INVALID_START_AT(HttpStatus.BAD_REQUEST, "4023", "시작일은 필수 입력 항목입니다."),
+    INVALID_END_AT(HttpStatus.BAD_REQUEST, "4024", "종료일은 필수 입력 항목입니다."),
+    INVALID_CREATED_AT(HttpStatus.BAD_REQUEST, "4025", "생성일은 필수 입력 항목입니다."),
+    INVALID_CATEGORIES(HttpStatus.BAD_REQUEST, "4026", "카테고리는 최소 1개 이상 선택해야 합니다."),
 
 
 
@@ -48,6 +53,7 @@ public enum ErrorCode {
     PAYMENT_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "4044", "결제 타입을 찾을 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "4045", "유저 정보를 찾을 수 없습니다."),
     SCORE_NOT_FOUND(HttpStatus.NOT_FOUND, "4046", "저장 되어있는 점수가 없습니다."),
+    CHALLENGE_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "4047", "챌린지 타입을 찾을 수 없습니다."),
 
     /* 409 CONFLICT */
     CONFLICT(HttpStatus.CONFLICT, "4091", "요청 충돌이 발생했습니다."),

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/global/error/ErrorCode.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/global/error/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
     SCORE_NOT_FOUND(HttpStatus.NOT_FOUND, "4046", "저장 되어있는 점수가 없습니다."),
     CHALLENGE_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "4047", "챌린지 타입을 찾을 수 없습니다."),
     CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "4048", "진행 중인 챌린지를 찾을 수 없습니다."),
+    CERTAIN_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "4049", "특정 챌린지를 찾을 수 없습니다."),
 
     /* 409 CONFLICT */
     CONFLICT(HttpStatus.CONFLICT, "4091", "요청 충돌이 발생했습니다."),

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/global/error/ErrorCode.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/global/error/ErrorCode.java
@@ -54,6 +54,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "4045", "유저 정보를 찾을 수 없습니다."),
     SCORE_NOT_FOUND(HttpStatus.NOT_FOUND, "4046", "저장 되어있는 점수가 없습니다."),
     CHALLENGE_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "4047", "챌린지 타입을 찾을 수 없습니다."),
+    CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "4048", "진행 중인 챌린지를 찾을 수 없습니다."),
 
     /* 409 CONFLICT */
     CONFLICT(HttpStatus.CONFLICT, "4091", "요청 충돌이 발생했습니다."),

--- a/wise-spending-life/src/test/java/com/wisespendinglife/wise_spending_life/domain/challenge/ChallengeDomainTest.java
+++ b/wise-spending-life/src/test/java/com/wisespendinglife/wise_spending_life/domain/challenge/ChallengeDomainTest.java
@@ -1,0 +1,162 @@
+package com.wisespendinglife.wise_spending_life.domain.challenge;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wisespendinglife.wise_spending_life.domain.category.entity.Category;
+import com.wisespendinglife.wise_spending_life.domain.category.repository.CategoryRepository;
+import com.wisespendinglife.wise_spending_life.domain.challenge.dto.ChallengeCreateRequestDto;
+import com.wisespendinglife.wise_spending_life.domain.challenge.entity.Challenge;
+import com.wisespendinglife.wise_spending_life.domain.challenge.entity.ChallengeType;
+import com.wisespendinglife.wise_spending_life.domain.challenge.repository.ChallengeRepository;
+import com.wisespendinglife.wise_spending_life.domain.user.entity.UserEntity;
+import com.wisespendinglife.wise_spending_life.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("local")
+public class ChallengeDomainTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private ChallengeRepository challengeRepository;
+
+    @Autowired
+    JdbcTemplate jdbc;
+
+    private UserEntity savedUser;
+    private Category savedCategory;
+    private Challenge savedChallenge;
+
+    @BeforeEach
+    void setUp() {
+        // User data
+        UserEntity user = UserEntity.builder()
+                .name("테스트")
+                .email("korea@kw.ac.kr")
+                .age(20L)
+                .gender("남자")
+                .location("서울시 강북구")
+                .baseAmount(100000L)
+                .phoneNumber("010-1234-5678")
+                .profileImgUrl("https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png")
+                .isDeleted(false)
+                .build();
+        savedUser = userRepository.save(user);
+
+        // AFTER
+        Category category = Category.builder()
+                .name("OUTFLOW")
+                .build();
+        savedCategory = categoryRepository.save(category);
+
+        Challenge challenge = Challenge.builder()
+                .user(savedUser)
+                .isCompleted(false)
+                .isDeleted(false)
+                .challengeName("공통 챌린지")
+                .startAt(LocalDate.now())
+                .endAt(LocalDate.now().plusDays(5))
+                .challengeType(ChallengeType.PAY_NOT)
+                .build();
+        savedChallenge = challengeRepository.save(challenge);
+    }
+
+    @BeforeEach
+    void dropPrepared() {
+        jdbc.execute("DEALLOCATE ALL");
+    }
+
+    @Test
+    @DisplayName("성공: 챌린지 생성")
+    void createChallenge_success() throws Exception {
+        // given
+        ChallengeCreateRequestDto requestDto = ChallengeCreateRequestDto.builder()
+                .user_id(savedUser.getId())
+                .challengeName("식비 챌린지")
+                .challengeType(ChallengeType.PAY_LESS)
+                .challengeDays(7L)
+                .startAt(LocalDate.now())
+                .endAt(LocalDate.now().plusDays(7))
+                .createdAt(LocalDate.now())
+                .categories(List.of(savedCategory.getName()))
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/api/challenges")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.msg").value("챌린지가 성공적으로 생성되었습니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("성공: 유효한 챌린지 조회")
+    void getValidChallenge_success() throws Exception {
+        mockMvc.perform(get("/api/challenges")
+                        .param("isCompleted", "false")
+                        .param("isDeleted", "false"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.challengeName").value("공통 챌린지"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("성공: 특정 챌린지 상세 조회")
+    void getChallengeById_success() throws Exception {
+        mockMvc.perform(get("/api/challenges/{challenge_id}", savedChallenge.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(savedChallenge.getId()))
+                .andExpect(jsonPath("$.challengeName").value("공통 챌린지"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("성공: 특정 챌린지 삭제(Soft Delete)")
+    void deleteChallenge_success() throws Exception {
+        // given
+        Long challengeId = savedChallenge.getId();
+
+        // when
+        mockMvc.perform(delete("/api/challenges/{challenge_id}", challengeId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("챌린지를 성공적으로 삭제했습니다."))
+                .andDo(print());
+
+        // then
+        Challenge deletedChallenge = challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new AssertionError("챌린지가 DB에서 삭제되었습니다."));
+        assertThat(deletedChallenge.getIsDeleted()).isTrue();
+    }
+}

--- a/wise-spending-life/src/test/java/com/wisespendinglife/wise_spending_life/domain/challenge/ChallengeDomainTest.java
+++ b/wise-spending-life/src/test/java/com/wisespendinglife/wise_spending_life/domain/challenge/ChallengeDomainTest.java
@@ -117,7 +117,18 @@ public class ChallengeDomainTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.msg").value("챌린지가 성공적으로 생성되었습니다."))
+                .andExpect(jsonPath("$.id").isNumber())
+                .andExpect(jsonPath("$.user_id").value(savedUser.getId()))
+                .andExpect(jsonPath("$.challengeName").value("식비 챌린지"))
+                .andExpect(jsonPath("$.challengeType").value("pay_less"))
+                .andExpect(jsonPath("$.challengeDays").value(7))
+                .andExpect(jsonPath("$.startAt").value(requestDto.getStartAt().toString()))
+                .andExpect(jsonPath("$.endAt").value(requestDto.getEndAt().toString()))
+                .andExpect(jsonPath("$.createdAt").value(requestDto.getCreatedAt().toString()))
+                .andExpect(jsonPath("$.categories[0]").value(savedCategory.getName()))
+                .andExpect(jsonPath("$.characterImageUrl").value("url"))
+                .andExpect(jsonPath("$.isCompleted").value(false))
+                .andExpect(jsonPath("$.isDeleted").value(false))
                 .andDo(print());
     }
 


### PR DESCRIPTION
## ✨ 새로운 기능
<추가된 기능에 대한 간단한 설명>
챌린지 도메인 API 생성
## 🔧 주요 변경 사항
- [ ] 유효 챌린지, 챌린지 생성, 특정 챌린지 조회, 특정 챌린지 삭제 생성
- [ ] <구현한 사항 2>

## ✅ 테스트 계획
- [ ] <테스트 케이스 1>
- [ ] <테스트 케이스 2>

## 📝 기타 사항
<특이사항이나 추가 논의가 필요한 내용>
1. 특정 챌린지 삭제 시에 현재는 soft delete로 코드를 작성해두었는데, 이를 그대로 사용할 것인가.
2. 추천 챌린지 생성 API 제작 필요. 새로운 DB 제작을 할 것인가 아니면 기존 챌린지 DB에 특정 값을 null로 해서 저장할 것인가.