### PR TITLE
[Feature] Gifticon 전체 조회 로직 수정

### DIFF
--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/gifticon/controller/GifticonController.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/gifticon/controller/GifticonController.java
@@ -25,12 +25,12 @@ public class GifticonController {
     //기프티콘 전체 조회
     @GetMapping
     public ResponseEntity<GifticonListResponseDTO> getAll(
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-            LocalDateTime lastCreatedAt,
+            @RequestParam(required = false) String lastStoreName,
+            @RequestParam(required = false) String lastGifticonName,
             @RequestParam(required = false) Long lastId,
             @RequestParam(defaultValue = "10") int size
     ) {
-        return ResponseEntity.ok(gifticonService.getAllGifticon(lastCreatedAt, lastId, size));
+        return ResponseEntity.ok(gifticonService.getAllGifticon(lastStoreName, lastGifticonName,lastId, size));
     }
 
 

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/gifticon/dto/GifticonListResponseDTO.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/gifticon/dto/GifticonListResponseDTO.java
@@ -16,8 +16,9 @@ public class GifticonListResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class Cursor {
+        private String lastStoreName; //마지막 상품 브랜드명
+        private String lastGifticonName; //마지막 상품 기프티콘명
         private Long lastId;
-        private LocalDateTime lastCreatedAt;
     }
 
     private List<GifticonResponseDTO> gifticonlist; // 실제 데이터

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/gifticon/entity/GifticonEntity.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/gifticon/entity/GifticonEntity.java
@@ -73,5 +73,6 @@ public class GifticonEntity {
     public void updateCreatedAt(LocalDateTime createdAt){
         this.createdAt = createdAt;
     }
+    public void updateStore(StoreEntity store){this.store = store;}
 
 }

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/gifticon/repository/GifticonRepository.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/gifticon/repository/GifticonRepository.java
@@ -13,17 +13,19 @@ import java.util.Optional;
 public interface GifticonRepository extends JpaRepository<GifticonEntity, Long> {
     //전체 조회 (스크롤기반)
     @Query("""
-        SELECT g
-        FROM GifticonEntity g
-        WHERE g.isDeleted = false
-          AND (
-                g.createdAt < :lastCreatedAt
-                OR (g.createdAt = :lastCreatedAt AND g.id < :lastId)
-              )
-        ORDER BY g.createdAt DESC, g.id DESC
-    """)
-    List<GifticonEntity> findAfterCursor(
-            @Param("lastCreatedAt") LocalDateTime lastCreatedAt,
+    SELECT g
+    FROM GifticonEntity g
+    WHERE g.isDeleted = false
+      AND (
+            g.store.storeName > :lastStoreName
+         OR (g.store.storeName = :lastStoreName AND g.name > :lastGifticonName)
+         OR (g.store.storeName = :lastStoreName AND g.name = :lastGifticonName AND g.id > :lastId)
+      )
+    ORDER BY g.store.storeName ASC, g.name ASC, g.id ASC
+""")
+    List<GifticonEntity> findAfterCursorByStoreNameAndGifticonName(
+            @Param("lastStoreName") String lastStoreName,
+            @Param("lastGifticonName") String lastGifticonName,
             @Param("lastId") Long lastId,
             Pageable pageable
     );

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/gifticon/service/GifticonService.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/gifticon/service/GifticonService.java
@@ -9,7 +9,8 @@ import java.time.LocalDateTime;
 
 public interface GifticonService {
 
-    GifticonListResponseDTO getAllGifticon(LocalDateTime lastCreatedAt, Long lastId, int size); //기프티콘 전체 조회(스크롤)
+     //기프티콘 전체 조회(스크롤)
+    GifticonListResponseDTO getAllGifticon(String lastStoreName, String lastGifticonName, Long lastId, int size);
 
     Long createGifticon(String storeName, GifticonRequestDTO requestDTO); //기프티콘 등록(Post)
 

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/gifticon/service/GifticonServiceImpl.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/gifticon/service/GifticonServiceImpl.java
@@ -37,20 +37,26 @@ public class GifticonServiceImpl implements GifticonService {
 
     @Override
     @Transactional(readOnly = true)
-    public GifticonListResponseDTO getAllGifticon(LocalDateTime lastCreatedAt, Long lastId, int size) {
-        if (size <= 0 || size > MAX_SIZE) {throw new BusinessException(ErrorCode.INVALID_PAGE_SIZE);}
-        if ((lastCreatedAt == null) != (lastId == null)) {throw new BusinessException(ErrorCode.INVALID_CURSOR);}
-
-        final boolean firstPage = (lastCreatedAt == null && lastId == null);
-        if (firstPage) {
-            lastCreatedAt = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
-            lastId = Long.MAX_VALUE;
+    public GifticonListResponseDTO getAllGifticon(String lastStoreName, String lastGifticonName, Long lastId, int size) {
+        if (size <= 0 || size > MAX_SIZE) {
+            throw new BusinessException(ErrorCode.INVALID_PAGE_SIZE);
+        }
+        if ((lastStoreName == null || lastGifticonName == null) != (lastId == null)) {
+            throw new BusinessException(ErrorCode.INVALID_CURSOR);
         }
 
-        // size+1 로 조회
-        // 가져온 리스트가 size+1 이면 마지막 하나를 잘라내고, 그 마지막 요소의 (createdAt, id)를 next로 보냄.
+        final boolean firstPage = (lastStoreName == null && lastGifticonName == null && lastId == null);
+        if (firstPage) {
+            // 가나다 정렬이므로 가장 작은 값으로 초기화
+            lastStoreName = "";
+            lastGifticonName = "";
+            lastId = 0L;
+        }
+
         Pageable pageable = PageRequest.of(0, size + 1);
-        List<GifticonEntity> entities = gifticonRepository.findAfterCursor(lastCreatedAt, lastId, pageable);
+        List<GifticonEntity> entities = gifticonRepository.findAfterCursorByStoreNameAndGifticonName(
+                lastStoreName, lastGifticonName, lastId, pageable
+        );
 
         if (entities.isEmpty() && firstPage) {
             throw new BusinessException(ErrorCode.GIFTICON_NOT_FOUND);
@@ -58,25 +64,25 @@ public class GifticonServiceImpl implements GifticonService {
 
         boolean hasNext = entities.size() > size;
         if (hasNext) {
-            entities = entities.subList(0, size); // 마지막 1개 제거
+            entities = entities.subList(0, size);
         }
 
-
-        var items = entities.stream().map(GifticonConverter::togifticonResponseDTO).toList();
+        var items = entities.stream()
+                .map(GifticonConverter::togifticonResponseDTO)
+                .toList();
 
         GifticonListResponseDTO.Cursor cursor = null;
         if (!items.isEmpty()) {
-            //GifticonResponseDTO last = items.get(items.size() - 1);
             var last = items.get(items.size() - 1);
             cursor = GifticonListResponseDTO.Cursor.builder()
                     .lastId(last.getId())
-                    .lastCreatedAt(last.getCreatedAt())
+                    .lastCreatedAt(last.getCreatedAt()) // 필요시 storeName, gifticonName도 포함 가능
                     .build();
         }
 
         return GifticonListResponseDTO.builder()
                 .gifticonlist(items)
-                .nextCursor(cursor)  // null 이면 프론트는 더 불러오지 않으면 됨
+                .nextCursor(cursor)
                 .hasNext(hasNext)
                 .size(size)
                 .build();

--- a/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/gifticon/service/GifticonServiceImpl.java
+++ b/wise-spending-life/src/main/java/com/wisespendinglife/wise_spending_life/domain/gifticon/service/GifticonServiceImpl.java
@@ -67,18 +67,23 @@ public class GifticonServiceImpl implements GifticonService {
             entities = entities.subList(0, size);
         }
 
+//        var items = entities.stream()
+//                .map(GifticonConverter::togifticonResponseDTO)
+//                .toList();
+
+        GifticonListResponseDTO.Cursor cursor = null;
+        if (!entities.isEmpty()) {
+            GifticonEntity lastEntity = entities.get(entities.size() - 1);
+            cursor = GifticonListResponseDTO.Cursor.builder()
+                    .lastId(lastEntity.getId())
+                    .lastStoreName(lastEntity.getStore().getStoreName()) //브랜드명
+                    .lastGifticonName(lastEntity.getName()) //기프티콘 이름
+                    .build();
+        }
+
         var items = entities.stream()
                 .map(GifticonConverter::togifticonResponseDTO)
                 .toList();
-
-        GifticonListResponseDTO.Cursor cursor = null;
-        if (!items.isEmpty()) {
-            var last = items.get(items.size() - 1);
-            cursor = GifticonListResponseDTO.Cursor.builder()
-                    .lastId(last.getId())
-                    .lastCreatedAt(last.getCreatedAt()) // 필요시 storeName, gifticonName도 포함 가능
-                    .build();
-        }
 
         return GifticonListResponseDTO.builder()
                 .gifticonlist(items)
@@ -158,18 +163,19 @@ public class GifticonServiceImpl implements GifticonService {
             entities = entities.subList(0, size); // 마지막 1개 제거
         }
 
+        GifticonListResponseDTO.Cursor cursor = null;
+        if (!entities.isEmpty()) {
+            GifticonEntity lastItem = entities.get(entities.size() - 1);
+            cursor = GifticonListResponseDTO.Cursor.builder()
+                    .lastId(lastItem.getId())
+                    .lastStoreName(lastItem.getStore().getStoreName()) //브랜드명
+                    .lastGifticonName(lastItem.getName()) //기프티콘 이름
+                    .build();
+        }
+
         var items = entities.stream()
                 .map(GifticonConverter::togifticonResponseDTO)
                 .toList();
-
-        GifticonListResponseDTO.Cursor cursor = null;
-        if (!items.isEmpty()) {
-            var lastItem = items.get(items.size() - 1);
-            cursor = GifticonListResponseDTO.Cursor.builder()
-                    .lastId(lastItem.getId())
-                    .lastCreatedAt(lastItem.getCreatedAt())
-                    .build();
-        }
 
         return GifticonListResponseDTO.builder()
                 .gifticonlist(items)


### PR DESCRIPTION
## ✨ 새로운 기능
기존 : 등록시간(createdAt) 내림차순 조회.
변경 후 : 브랜드별로 기프티콘을 묶어 조회. 브랜드명은 가나다순(오름차순) 정렬, 등일 브랜드 내에서는 기프티콘명이 사전식 순서로 정렬.

## 🔧 주요 변경 사항
- [ ] Gifiticon Controller, Service, ServiceImpl, Repository 수정함

## ✅ 테스트 계획
- [ ] <테스트 케이스 1>
- [ ] <테스트 케이스 2>

## 📝 기타 사항
<특이사항이나 추가 논의가 필요한 내용>
